### PR TITLE
Disallow openssl backend. Fixes #9

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
 #![deny(clippy::disallowed_methods)]
 
+// Don't forget to add new backends as they appear in unknown_order
+#[cfg(all(not(feature = "gmp"), not(feature = "rust")))]
+compile_error!(
+    "Attempting to build paillier-zk without a bignumber backend specified: \
+    please enable `rust` or `gmp` feature of `paillier-zk` (`openssl` backend is \
+    disabled as it doesn't support deterministic RNG)"
+);
+
 use thiserror::Error;
 
 mod common;


### PR DESCRIPTION
We can't directly check for features set by dependent crates, so as a proxy we check for our own features