### PR TITLE
Update `generic-ec` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64ct"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "block-buffer"
@@ -43,9 +43,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722e23542a15cea1f65d4a1419c4cfd7a26706c70871a13a04238ca3f40f1661"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "core2"
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dd2ae565c0a381dde7fade45fce95984c568bdcb4700a4fdbe3175e0380b2f"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -220,7 +220,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.5",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -274,10 +274,10 @@ dependencies = [
 [[package]]
 name = "generic-ec"
 version = "0.0.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#8e1c966d2995884a9c15b5decd7b5c02f4b4a1a4"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=m#c418c93b19fced622382d3df34368911b6b99731"
 dependencies = [
- "generic-array",
  "generic-ec-core",
+ "generic-ec-curves",
  "hex",
  "phantom-type",
  "rand_core",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "generic-ec-core"
 version = "0.1.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#8e1c966d2995884a9c15b5decd7b5c02f4b4a1a4"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=m#c418c93b19fced622382d3df34368911b6b99731"
 dependencies = [
  "generic-array",
  "rand_core",
@@ -302,10 +302,11 @@ dependencies = [
 [[package]]
 name = "generic-ec-curves"
 version = "0.1.0"
-source = "git+https://github.com/dfns-labs/generic-ec?branch=d#8e1c966d2995884a9c15b5decd7b5c02f4b4a1a4"
+source = "git+https://github.com/dfns-labs/generic-ec?branch=m#c418c93b19fced622382d3df34368911b6b99731"
 dependencies = [
  "elliptic-curve",
  "generic-ec-core",
+ "k256",
  "p256",
  "rand_core",
  "sha2",
@@ -371,7 +372,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -379,6 +380,20 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "k256"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92a55e0ff3b72c262bcf041d9e97f1b84492b68f1c1a384de2323d3dc9403397"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+ "signature",
+]
 
 [[package]]
 name = "lazy_static"
@@ -398,7 +413,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181151f174d449370cb6cf4472191f1b602e77ce233d1b314f8dbbecb3a4b16"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "serde",
  "serde_bare",
  "unknown_order",
@@ -443,13 +458,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.11.1"
+name = "once_cell"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "p256"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49c124b3cbce43bcbac68c58ec181d98ed6cc7e6d0aa7c3ba97b2563410b0e55"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2",
 ]
 
@@ -458,8 +480,6 @@ name = "paillier-zk"
 version = "0.1.0"
 dependencies = [
  "generic-ec",
- "generic-ec-core",
- "generic-ec-curves",
  "libpaillier",
  "rand_chacha",
  "rand_core",
@@ -496,6 +516,15 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "primeorder"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b54f7131b3dba65a2f414cf5bd25b66d4682e4608610668eae785750ba4c5b2"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -690,16 +719,16 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.5",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.7",
  "rand_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-generic-ec = { git = "https://github.com/dfns-labs/generic-ec", branch = "d" }
-generic-ec-core = { git = "https://github.com/dfns-labs/generic-ec", branch = "d" }
+generic-ec = { git = "https://github.com/dfns-labs/generic-ec", branch = "m" }
 rand_core = { version = "0.6", default-features = false }
 rand_chacha = { version = "0.3", default-features = false }
 libpaillier = { version = "0.5", default-features = false }
@@ -22,7 +21,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 serde_with = { version = "3", default-features = false, features = ["macros"], optional = true }
 
 [dev-dependencies]
-generic-ec-curves = { git = "https://github.com/dfns-labs/generic-ec", branch = "d", features = ["secp256r1"] }
+generic-ec = { git = "https://github.com/dfns-labs/generic-ec", branch = "m", features = ["all-curves"] }
 rand_dev = { version = "0.1.0", default-features = false }
 
 [features]

--- a/src/common.rs
+++ b/src/common.rs
@@ -350,7 +350,7 @@ pub mod test {
     fn conversion() {
         // checks that bignumbers use BE encoding, same as the method we use in
         // conversion
-        type Scalar = generic_ec::Scalar<generic_ec_curves::Secp256r1>;
+        type Scalar = generic_ec::Scalar<generic_ec::curves::Secp256r1>;
         let number: u64 = 0x11_22_33_44_55_66_77_88;
         let bignumber = BigNumber::from(number);
         let scalar1 = Scalar::from(number);

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -11,7 +11,7 @@ impl From<u64> for MillionRing {
 
 const MODULO: u64 = 1_000_000_007;
 
-impl generic_ec_core::Additive for MillionRing {
+impl generic_ec::core::Additive for MillionRing {
     fn add(a: &Self, b: &Self) -> Self {
         ((a.0 + b.0) % MODULO).into()
     }
@@ -29,13 +29,13 @@ impl generic_ec_core::Additive for MillionRing {
     }
 }
 
-impl From<generic_ec_core::CurveGenerator> for MillionRing {
-    fn from(_: generic_ec_core::CurveGenerator) -> Self {
+impl From<generic_ec::core::CurveGenerator> for MillionRing {
+    fn from(_: generic_ec::core::CurveGenerator) -> Self {
         2u64.into()
     }
 }
 
-impl generic_ec_core::Zero for MillionRing {
+impl generic_ec::core::Zero for MillionRing {
     fn zero() -> Self {
         0u64.into()
     }
@@ -55,14 +55,14 @@ impl zeroize::Zeroize for MillionRing {
     }
 }
 
-impl generic_ec_core::OnCurve for MillionRing {
+impl generic_ec::core::OnCurve for MillionRing {
     #[inline]
     fn is_on_curve(&self) -> Choice {
         Choice::from(1)
     }
 }
 
-impl generic_ec_core::SmallFactor for MillionRing {
+impl generic_ec::core::SmallFactor for MillionRing {
     #[inline]
     fn is_torsion_free(&self) -> Choice {
         Choice::from(1)
@@ -81,7 +81,7 @@ impl subtle::ConditionallySelectable for MillionRing {
     }
 }
 
-impl generic_ec_core::CompressedEncoding for MillionRing {
+impl generic_ec::core::CompressedEncoding for MillionRing {
     type Bytes = [u8; 8];
 
     fn to_bytes_compressed(&self) -> Self::Bytes {
@@ -89,7 +89,7 @@ impl generic_ec_core::CompressedEncoding for MillionRing {
     }
 }
 
-impl generic_ec_core::UncompressedEncoding for MillionRing {
+impl generic_ec::core::UncompressedEncoding for MillionRing {
     type Bytes = [u8; 8];
 
     fn to_bytes_uncompressed(&self) -> Self::Bytes {
@@ -97,7 +97,7 @@ impl generic_ec_core::UncompressedEncoding for MillionRing {
     }
 }
 
-impl generic_ec_core::Decode for MillionRing {
+impl generic_ec::core::Decode for MillionRing {
     fn decode(bytes: &[u8]) -> Option<Self> {
         let x = u64::from_be_bytes(bytes.try_into().ok()?);
         Some(MillionRing(x % MODULO))
@@ -119,7 +119,7 @@ impl From<Scalar> for u64 {
     }
 }
 
-impl generic_ec_core::Additive for Scalar {
+impl generic_ec::core::Additive for Scalar {
     fn add(a: &Self, b: &Self) -> Self {
         ((a.0 + b.0) % MODULO).into()
     }
@@ -137,7 +137,7 @@ impl generic_ec_core::Additive for Scalar {
     }
 }
 
-impl generic_ec_core::Multiplicative<Scalar> for Scalar {
+impl generic_ec::core::Multiplicative<Scalar> for Scalar {
     type Output = Self;
 
     fn mul(a: &Self, b: &Self) -> Self {
@@ -145,7 +145,7 @@ impl generic_ec_core::Multiplicative<Scalar> for Scalar {
     }
 }
 
-impl generic_ec_core::Multiplicative<MillionRing> for Scalar {
+impl generic_ec::core::Multiplicative<MillionRing> for Scalar {
     type Output = MillionRing;
 
     fn mul(a: &Self, b: &MillionRing) -> MillionRing {
@@ -153,21 +153,24 @@ impl generic_ec_core::Multiplicative<MillionRing> for Scalar {
     }
 }
 
-impl generic_ec_core::Multiplicative<generic_ec_core::CurveGenerator> for Scalar {
+impl generic_ec::core::Multiplicative<generic_ec::core::CurveGenerator> for Scalar {
     type Output = MillionRing;
 
-    fn mul(a: &Self, _: &generic_ec_core::CurveGenerator) -> MillionRing {
-        generic_ec_core::Multiplicative::mul(a, &MillionRing::from(generic_ec_core::CurveGenerator))
+    fn mul(a: &Self, _: &generic_ec::core::CurveGenerator) -> MillionRing {
+        generic_ec::core::Multiplicative::mul(
+            a,
+            &MillionRing::from(generic_ec::core::CurveGenerator),
+        )
     }
 }
 
-impl generic_ec_core::Invertible for Scalar {
+impl generic_ec::core::Invertible for Scalar {
     fn invert(x: &Self) -> subtle::CtOption<Self> {
         subtle::CtOption::new(*x, x.ct_eq(&1u64.into()))
     }
 }
 
-impl generic_ec_core::Zero for Scalar {
+impl generic_ec::core::Zero for Scalar {
     fn zero() -> Self {
         0u64.into()
     }
@@ -177,7 +180,7 @@ impl generic_ec_core::Zero for Scalar {
     }
 }
 
-impl generic_ec_core::One for Scalar {
+impl generic_ec::core::One for Scalar {
     fn one() -> Self {
         1u64.into()
     }
@@ -187,7 +190,7 @@ impl generic_ec_core::One for Scalar {
     }
 }
 
-impl generic_ec_core::Samplable for Scalar {
+impl generic_ec::core::Samplable for Scalar {
     fn random<R: rand_core::RngCore>(rng: &mut R) -> Self {
         rng.next_u64().into()
     }
@@ -211,7 +214,7 @@ impl subtle::ConditionallySelectable for Scalar {
     }
 }
 
-impl generic_ec_core::IntegerEncoding for Scalar {
+impl generic_ec::core::IntegerEncoding for Scalar {
     type Bytes = [u8; 8];
 
     fn to_be_bytes(&self) -> Self::Bytes {
@@ -252,11 +255,11 @@ impl generic_ec::Curve for C {
     type CoordinateArray = [u8; 8];
 }
 
-impl generic_ec_core::hash_to_curve::HashToCurve for C {
+impl generic_ec::core::hash_to_curve::HashToCurve for C {
     fn hash_to_curve(
         tag: generic_ec::hash_to_curve::Tag,
         msgs: &[&[u8]],
-    ) -> Result<Self::Point, generic_ec_core::Error> {
+    ) -> Result<Self::Point, generic_ec::core::Error> {
         use sha2::Digest;
         let mut digest = sha2::Sha256::new();
         digest.update(tag.as_bytes());
@@ -272,7 +275,7 @@ impl generic_ec_core::hash_to_curve::HashToCurve for C {
     fn hash_to_scalar(
         tag: generic_ec::hash_to_curve::Tag,
         msgs: &[&[u8]],
-    ) -> Result<Self::Scalar, generic_ec_core::Error> {
+    ) -> Result<Self::Scalar, generic_ec::core::Error> {
         use sha2::Digest;
         let mut digest = sha2::Sha256::new();
         digest.update(tag.as_bytes());

--- a/src/group_element_vs_paillier_encryption_in_range.rs
+++ b/src/group_element_vs_paillier_encryption_in_range.rs
@@ -49,7 +49,7 @@
 //!
 //! // 2. Setup: prover has some plaintext, encrypts it and computes X
 //!
-//! type C = generic_ec_curves::Secp256r1;
+//! type C = generic_ec::curves::Secp256r1;
 //! let g = generic_ec::Point::<C>::generator().into();
 //!
 //! let plaintext: BigNumber = 228.into();
@@ -458,11 +458,11 @@ mod test {
 
     #[test]
     fn passing_p256() {
-        passing_test::<generic_ec_curves::rust_crypto::Secp256r1>()
+        passing_test::<generic_ec::curves::Secp256r1>()
     }
     #[test]
     fn failing_p256() {
-        failing_test::<generic_ec_curves::rust_crypto::Secp256r1>()
+        failing_test::<generic_ec::curves::Secp256r1>()
     }
 
     #[test]

--- a/src/paillier_affine_operation_in_range.rs
+++ b/src/paillier_affine_operation_in_range.rs
@@ -62,7 +62,7 @@
 //!
 //! // 2. Setup: prover prepares the group used to encrypt x
 //!
-//! type C = generic_ec_curves::Secp256r1;
+//! type C = generic_ec::curves::Secp256r1;
 //! let g = generic_ec::Point::<C>::generator();
 //!
 //! // 3. Setup: prover prepares all plain texts
@@ -615,15 +615,15 @@ mod test {
 
     #[test]
     fn passing_p256() {
-        passing_test::<generic_ec_curves::rust_crypto::Secp256r1>()
+        passing_test::<generic_ec::curves::Secp256r1>()
     }
     #[test]
     fn failing_p256_add() {
-        failing_on_additive::<generic_ec_curves::rust_crypto::Secp256r1>()
+        failing_on_additive::<generic_ec::curves::Secp256r1>()
     }
     #[test]
     fn failing_p256_mul() {
-        failing_on_multiplicative::<generic_ec_curves::rust_crypto::Secp256r1>()
+        failing_on_multiplicative::<generic_ec::curves::Secp256r1>()
     }
 
     #[test]


### PR DESCRIPTION
* `paillier-zk` depends on branch `d` of `generic-ec` repo which was recently deleted. This PR updates the dependency.
* PR removes dependencies on `generic-ec-core` and `generic-ec-curves` as `generic-ec` provides access to both these crates without specifying them explicitly