### PR TITLE
Export HashRng from crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ compile_error!("doctest require that `__internal_doctest` feature is turned on")
 pub mod _doctest;
 
 use common::InvalidProofReason;
-pub use common::{BadExponent, IntegerExt, InvalidProof, PaillierError};
+pub use common::{rng, BadExponent, IntegerExt, InvalidProof, PaillierError};
 pub use {fast_paillier, rug, rug::Integer};
 
 /// Library general error type


### PR DESCRIPTION
Turns out this functionality is useful in cggmp is well, and we use it now instead of HashToScalar